### PR TITLE
1.11

### DIFF
--- a/Arduino Sketches/Main/Incuvers_Incubator/Env_Heat.h
+++ b/Arduino Sketches/Main/Incuvers_Incubator/Env_Heat.h
@@ -244,6 +244,20 @@ class IncuversHeatingSystem {
       #endif
       this->EMHandleDoor.Disable();
       this->EMHandleChamber.Disable();
+      digitalWrite(this->pinAssignment_Fan, LOW);        // Turn off the Fan
+    }
+
+    void ResumeState(int heatMode) {
+      #ifdef DEBUG_TEMP
+        Serial.println(F("Heat::ResumeState"));
+      #endif
+      if (heatMode != 0) {
+        this->EMHandleChamber.Enable();
+        this->EMHandleDoor.Enable();
+      }
+      if (this->fanMode == 4) {
+        digitalWrite(this->pinAssignment_Fan, HIGH);       // Turn on the Fan  
+      } 
     }
 
     void DoQuickTick() {
@@ -290,7 +304,7 @@ class IncuversHeatingSystem {
     }
 
     boolean isAlarmed() {
-      if (this->EMHandleDoor.isAlarm_Overshoot() || this->EMHandleDoor.isAlarm_Undershoot() || this->EMHandleChamber.isAlarm_Overshoot() || this->EMHandleChamber.isAlarm_Undershoot()) {
+      if (this->EMHandleDoor.isAlarm_Overshoot() || this->EMHandleChamber.isAlarm_Overshoot() || this->EMHandleChamber.isAlarm_Undershoot()) {
         return true;
       } else {
         return false;

--- a/Arduino Sketches/Main/Incuvers_Incubator/Incuvers_Incubator.ino
+++ b/Arduino Sketches/Main/Incuvers_Incubator/Incuvers_Incubator.ino
@@ -1,12 +1,13 @@
 /*
  * INCUVERS INCUBATOR 
- *    Date:    October 2018
+ *    Date:    March 2019
  *    Software version: 1.11
- *    Hardware version: 1.0.0
+ *    Hardware version: 1.0.1
  *    http://incuvers.com/   
  *    
  *    Incuvers team:
  *        Dr. Sebastian Hadjiantoniou
+ *        David Sean
  *        Tim Spekkens
  */
 
@@ -18,6 +19,9 @@
   *      - Moved common environmental management code into its own class.
   *      - Moved to support Control Board 1.0.0 / ATMEGA 2560 controller.
   *      - Added some power management features to limit the current draw.
+  *      - Temporarily disabled alarms due to a bad buzzer on 1.0.1 PCBs.
+  *      - Modified the minimum allowed value for O2 and CO2 setpoint.
+  *      - Modified the LCD screen to only update once per second.
   *      
   * 1.10 - Added support for chamber lighting control.
   *      - Started making modules/skeletons to save on memory in Atmega328 implementations.

--- a/Arduino Sketches/Main/Incuvers_Incubator/Incuvers_Incubator.ino
+++ b/Arduino Sketches/Main/Incuvers_Incubator/Incuvers_Incubator.ino
@@ -21,6 +21,7 @@
   *      - Added some power management features to limit the current draw.
   *      - Temporarily disabled alarms due to a bad buzzer on 1.0.1 PCBs.
   *      - Modified the minimum allowed value for O2 and CO2 setpoint.
+  *      - Fixed heat resume after settings screen.
   *      - Modified the LCD screen to only update once per second.
   *      
   * 1.10 - Added support for chamber lighting control.
@@ -61,7 +62,7 @@
 //#define DEBUG_SERIAL true
 //#define DEBUG_EEPROM true
 //#define DEBUG_UI true
-#define DEBUG_EM true
+//#define DEBUG_EM true
 //#define DEBUG_CO2 true
 //#define DEBUG_O2 true
 //#define DEBUG_TEMP true
@@ -74,8 +75,8 @@
 //#define INCLUDE_O2_ANALOG true
 #define INCLUDE_CO2 true
 #define INCLUDE_TEMP true
-#define INCLUDE_LIGHT true
-#define INCLUDE_PILINK true
+//#define INCLUDE_LIGHT true
+//#define INCLUDE_PILINK true
 
 // Hardwired settings
 #define PINASSIGN_ONEWIRE_BUS 4

--- a/Arduino Sketches/Main/Incuvers_Incubator/Incuvers_Settings.h
+++ b/Arduino Sketches/Main/Incuvers_Incubator/Incuvers_Settings.h
@@ -529,6 +529,13 @@ class IncuversSettingsHandler {
       incO2->MakeSafeState();
     }
 
+    void ReturnFromSafeState() {
+      incHeat->ResumeState(this->settingsHolder.heatMode);
+      // Lighting will resume automatically
+      // CO2 doesn't use EM which requires a restart signal
+      // O2 doesn't use EM which requires a restart signal
+    }
+
     int getLightMode() {
       return this->settingsHolder.lightMode;
     }


### PR DESCRIPTION
- Temporarily disabled alarms due to a bad buzzer on 1.0.1 PCBs.
- Fixed heating issues after entering settings mode.  Fixes #24 
- Modified the minimum allowed value for O2 and CO2 setpoint.  Fixes #23
- Modified the LCD screen to only update once per second.